### PR TITLE
Fixing some previous naming inconsistencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ export ISSUE_NUM=$5
 export ADO_TOKEN=$6
 export GITHUB_TOKEN=$7
 
-dotnet /GhSync.dll pull-gh $GH_REPO $ISSUE_NUM
+dotnet /gh-sync.dll pull-gh $GH_REPO $ISSUE_NUM

--- a/install.ps1
+++ b/install.ps1
@@ -33,6 +33,7 @@ if ($ghSync) {
     # Finally, copy into new path.
     $target = $ghBin;
 }
-
+Push-Location (Join-Path $PSScriptRoot "src/GhSync");
 dotnet publish --self-contained --runtime win10-x64 /p:PublishSingleFile=true
-Copy-Item bin/Debug/net6.0-windows10.0.19041.0/win10-x64/publish/gh-sync.exe $target
+Copy-Item bin/Debug/net6.0-windows/win10-x64/publish/gh-sync.exe $target
+Pop-Location;

--- a/src/GhSync/GhSync.csproj
+++ b/src/GhSync/GhSync.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <RootNamespace>gh_sync</RootNamespace>
     <Nullable>enable</Nullable>
+    <AssemblyName>gh-sync</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of the install script paths and executable names were inconsistent, so just updated everything.