### PR TITLE
Adding a CLI option for setting the work item type of ADO issue

### DIFF
--- a/src/GhSync/Extensions/Extensions.cs
+++ b/src/GhSync/Extensions/Extensions.cs
@@ -130,14 +130,14 @@ public static class Extensions
     {
         if (issue.IsLabeledAs("bug", "Kind-Bug"))
         {
-            return "Bug";
+            return "Task";
         }
         else if (issue.IsLabeledAs("enhancement", "Kind-Enhancement"))
         {
             return "Task";
         }
         // Default to "bug" if we don't know anything more specific.
-        return "Bug";
+        return "Task";
     }
 
     internal static string MarkdownToHtml(this string source)

--- a/src/GhSync/Services/ISynchronizer.cs
+++ b/src/GhSync/Services/ISynchronizer.cs
@@ -12,12 +12,12 @@ namespace Microsoft.GhSync;
 public interface ISynchronizer
 {
 
-    Task PullGitHubIssue(Issue ghIssue, bool dryRun = false, bool allowExisting = false);
+    Task PullGitHubIssue(Issue ghIssue, bool dryRun = false, bool allowExisting = false, string? workItemType = null);
 
     Task<WorkItem> UpdateState(WorkItem workItem, Issue issue);
 
     IAsyncEnumerable<Comment> UpdateCommentsFromIssue(WorkItem workItem, Issue? issue);
-    Task<WorkItem> PullWorkItemFromIssue(Issue? issue);
+    Task<WorkItem> PullWorkItemFromIssue(Issue? issue, string? workItemType);
     Task PullAllIssues(string repo, bool dryRun, bool allowExisting);
 
 }


### PR DESCRIPTION
For more Devrel workflows, there isn't always a concrete mapping of GH issue tags to ADO work item types isn't direct. This PR adds a way to as a command line option specify the correct ADO work item type that overrides any other defaults.